### PR TITLE
Upgrade Elastix to svn revision 5219

### DIFF
--- a/Code/Elastix/include/sitkSimpleTransformix.h
+++ b/Code/Elastix/include/sitkSimpleTransformix.h
@@ -31,6 +31,7 @@ class SITKCommon_EXPORT SimpleTransformix
     typedef itk::ParameterFileParser                       ParameterFileParserType;
     typedef ParameterFileParserType::Pointer               ParameterFileParserPointer;
     typedef ParameterObjectType::ParameterKeyType          ParameterKeyType;
+    typedef ParameterObjectType::ParameterValueType        ParameterValueType;
     typedef ParameterObjectType::ParameterValueVectorType  ParameterValueVectorType;
 
     /** To be wrapped by SWIG */ 
@@ -105,7 +106,7 @@ class SITKCommon_EXPORT SimpleTransformix
     Image Execute( void );
 
     Image GetResultImage( void );
-    std::vector< std::map< std::string, std::vector< std::string > > > GetTransformParameterMap( void );
+    
 
   private:
 

--- a/SuperBuild/External_Elastix.cmake
+++ b/SuperBuild/External_Elastix.cmake
@@ -7,6 +7,9 @@ set( ELASTIX_REVISION 5219 )
 ExternalProject_Add( ${proj} 
   SVN_REPOSITORY ${ELASTIX_REPOSITORY}
   SVN_REVISION -r ${ELASTIX_REVISION}
+  SVN_USERNAME "elastixguest"
+  SVN_PASSWORD "elastixguest"
+  SVN_TRUST_CERT 1
   UPDATE_COMMAND ""
   SOURCE_DIR ${proj}
   BINARY_DIR ${proj}-build

--- a/SuperBuild/External_Elastix.cmake
+++ b/SuperBuild/External_Elastix.cmake
@@ -2,7 +2,7 @@ set( proj elastix )
 
 file( WRITE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-build/CMakeCacheInit.txt" "${ep_common_cache}" )
 set( ELASTIX_REPOSITORY https://svn.bigr.nl/elastix/trunkpublic/ )
-set( ELASTIX_REVISION 5211 )
+set( ELASTIX_REVISION 5219 )
 
 ExternalProject_Add( ${proj} 
   SVN_REPOSITORY ${ELASTIX_REPOSITORY}


### PR DESCRIPTION
Revision 5211 wouldn’t compile on OS X (don't have logs anymore, but tried twice, and old version still works). Updating to 5219 fixed the issue.