### PR TITLE
DOC: Updated groupwise registration docs with note on tolerances and setting image origins

### DIFF
--- a/Documentation/source/GroupwiseRegistration.rst
+++ b/Documentation/source/GroupwiseRegistration.rst
@@ -40,6 +40,8 @@ Elastix takes a single N+1 dimensional image for groupwise registration. Therefo
     elastix.SetParameterMap(selx.GetDefaultParameterMap('groupwise'))
     elastix.Execute()
 
+A few things to note. While using :code:`JoinSeries`there may be an error notifying you that the "Inputs do not occupy the same physical space!". These can be caused by slight differences between the image origins, spacing, or axes. The tolerance that SimpleITK uses for these can be adjusted using :code: `sitk.ProcessObject.SetGlobalDefaultDirectionTolerance(x)` and :code: `sitk.ProcessObject.SetGlobalDefaultCoordinateTolerance(x)`. Furthermore, you may need to change the origin to make sure they all align. This can be done by copying the origin of one of the images :code:`origin = firstImage.GetOrigin()` and setting it to the others :code:`otherImages.SetOrigin(origin)`
+
 While the groupwise transform works only on the moving image we need to pass a dummy fixed image is to prevent elastix from throwing errors. This does not consume extra memory as only pointers are passed internally. 
 
 The result image is shown in Figure 13. It is clear that anatomical correpondence is obtained in many regions of the brain. However, there are a some anatomical regions that have not been registered correctly, particularly near Corpus Collosum. Generally these kinds of difficult registration problems require a lot of parameter tuning. No way around that. In a later chapter we introduce methods for assessment of registration quality.


### PR DESCRIPTION
Hey Kasper, 

I think I have it now. Hopefully the commit message is a bit better now and the pull request is to the correct location. 

I have some more issues I have run into with the program, they are mostly problems with using 4D images and I did have the sitk 4D turned to on when I built simple elastix. Would you like me to continue to report issues? I feel like a bit of a pest. I don't mind continually updating the docs to help others that come behind me. 

Anthony. 

