### PR TITLE
Enable generation of Lua loadable module

### DIFF
--- a/Wrapping/CMakeLists.txt
+++ b/Wrapping/CMakeLists.txt
@@ -71,6 +71,14 @@ if ( WRAP_LUA )
   target_link_libraries ( SimpleITKLua ${SimpleITK_LIBRARIES} ${LUA_LIB} )
   sitk_strip_target( SimpleITKLua )
 
+  # Create a SimpleITK Lua module that can be loaded into any Lua executable.
+  SWIG_add_module( SimpleITKLuaModule lua SimpleITK.i )
+  target_link_libraries( ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} ${SimpleITK_LIBRARIES} )
+  set_target_properties( ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} PROPERTIES PREFIX "" OUTPUT_NAME  "SimpleITK" )
+  target_link_libraries ( ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} ${SimpleITK_LIBRARIES} ${LUA_LIB} )
+  set_source_files_properties( ${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "-w")
+  sitk_strip_target( ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} )
+
 endif()
 
 #


### PR DESCRIPTION
This change generates the shared object build/SimpleITK-build/lib/SimpleITK.so, which can be loaded by any Lua interpreter.

I couldn't find any way to generate a loadable lua module from the original download, only a standalone lua interpreter was created.

These lines of code come from the CMakeLists.txt file of SimpleITK.

I'm no expert of CMake so I'm not sure if this is the right way of doing it; however, it worked for me.